### PR TITLE
config clone

### DIFF
--- a/pkg/math/curve/curve.go
+++ b/pkg/math/curve/curve.go
@@ -95,6 +95,8 @@ type Scalar interface {
 	IsZero() bool
 	// Set mutates this Scalar, replacing its value with another.
 	Set(Scalar) Scalar
+	// Clone creates a deep copy of this Scalar, safe to use in a concurrent environment.
+	Clone() Scalar
 	// SetNat mutates this Scalar, replacing it with the value of a number.
 	//
 	// This number must be interpreted modulo the order of the group.

--- a/pkg/math/curve/secp256k1.go
+++ b/pkg/math/curve/secp256k1.go
@@ -142,6 +142,17 @@ func (*Secp256k1Scalar) Curve() Curve {
 	return Secp256k1{}
 }
 
+func (s *Secp256k1Scalar) Clone() Scalar {
+	if s == nil {
+		return nil
+	}
+
+	copy := new(Secp256k1Scalar)
+	copy.Set(s)
+
+	return copy
+}
+
 var errNilScalar = errors.New("secp256k1Scalar is nil")
 
 func (s *Secp256k1Scalar) MarshalBinary() ([]byte, error) {

--- a/protocols/frost/keygen/config.go
+++ b/protocols/frost/keygen/config.go
@@ -3,6 +3,7 @@ package keygen
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/xlabs/multi-party-sig/internal/bip32"
 	"github.com/xlabs/multi-party-sig/internal/params"
@@ -137,6 +138,31 @@ func (r *Config) DeriveChild(i uint32) (*Config, error) {
 		return nil, err
 	}
 	return r.Derive(scalar, newChainKey)
+}
+
+// Clone creates a deep clone of this struct, and all the values contained inside.
+// This method is safe to run along read operations, but not alongside mutating
+// operations.
+func (r *Config) Clone() (*Config, error) {
+	if r == nil || !r.ValidateBasic() {
+		return nil, errors.New("invalid config")
+	}
+
+	// since NewPointMap doesn't clone the points inside, we do it ourselves here.
+	vs := make(map[party.ID]curve.Point, len(r.VerificationShares.Points))
+	for k, v := range r.VerificationShares.Points {
+		vs[k] = v.Clone()
+	}
+	shares := party.NewPointMap(vs)
+
+	return &Config{
+		ID:                 r.ID,
+		Threshold:          r.Threshold,
+		PrivateShare:       r.PrivateShare.Clone(),
+		PublicKey:          r.PublicKey.Clone(),
+		ChainKey:           slices.Clone(r.ChainKey),
+		VerificationShares: shares,
+	}, nil
 }
 
 // TaprootConfig is like result, but for Taproot / BIP-340 keys.

--- a/protocols/frost/keygen/config.go
+++ b/protocols/frost/keygen/config.go
@@ -140,12 +140,21 @@ func (r *Config) DeriveChild(i uint32) (*Config, error) {
 	return r.Derive(scalar, newChainKey)
 }
 
+var (
+	errNilConfig     = errors.New("nil config")
+	errInvalidConfig = errors.New("invalid config")
+)
+
 // Clone creates a deep clone of this struct, and all the values contained inside.
 // This method is safe to run along read operations, but not alongside mutating
 // operations.
 func (r *Config) Clone() (*Config, error) {
-	if r == nil || !r.ValidateBasic() {
-		return nil, errors.New("invalid config")
+	if r == nil {
+		return nil, errNilConfig
+	}
+
+	if !r.ValidateBasic() {
+		return nil, errInvalidConfig
 	}
 
 	// since NewPointMap doesn't clone the points inside, we do it ourselves here.


### PR DESCRIPTION
I've found that using the same config over different sessions concurrently isn't safe:
`frost.sign.round3` applies data-mutating operations on config values. As a result, it isn't thread-safe and might cause 
data race errors when multiple sessions make use of the same config. 
To ensure this doesn't affect users, this PR adds code to deep-copy the config upon FROST's `sign` session creation.